### PR TITLE
Update db schemas

### DIFF
--- a/current_database_schem.xml
+++ b/current_database_schem.xml
@@ -37,7 +37,7 @@
     <type label="SET" length="1" sql="SET" quote=""/>
     <type label="Bit" length="0" sql="bit" quote=""/>
   </group>
-</datatypes><table x="576" y="341" name="Users">
+</datatypes><table x="627" y="524" name="Users">
 <row name="id" null="1" autoincrement="1">
 <datatype>INTEGER</datatype>
 <default>NULL</default></row>
@@ -54,7 +54,7 @@
 <part>id</part>
 </key>
 </table>
-<table x="221" y="143" name="super_categories">
+<table x="422" y="155" name="super_categories">
 <row name="id" null="1" autoincrement="1">
 <datatype>INTEGER</datatype>
 <default>NULL</default></row>
@@ -81,11 +81,14 @@
 <row name="minimum_age" null="1" autoincrement="0">
 <datatype>INTEGER</datatype>
 <default>NULL</default></row>
+<row name="description" null="1" autoincrement="0">
+<datatype>VARCHAR</datatype>
+<default>NULL</default></row>
 <key type="PRIMARY" name="">
 <part>id</part>
 </key>
 </table>
-<table x="582" y="61" name="video_categories">
+<table x="691" y="51" name="video_categories">
 <row name="id" null="1" autoincrement="1">
 <datatype>INTEGER</datatype>
 <default>NULL</default></row>
@@ -120,7 +123,7 @@
 <part>id</part>
 </key>
 </table>
-<table x="280" y="305" name="scores">
+<table x="496" y="269" name="score">
 <row name="id" null="1" autoincrement="1">
 <datatype>INTEGER</datatype>
 <default>NULL</default></row>
@@ -138,26 +141,29 @@
 <row name="viewed_videos" null="1" autoincrement="0">
 <datatype>INTEGER</datatype>
 <default>NULL</default></row>
+<row name="interest_score" null="1" autoincrement="0">
+<datatype>INTEGER</datatype>
+<default>NULL</default></row>
 <key type="PRIMARY" name="">
 <part>id</part>
 </key>
 </table>
-<table x="485" y="198" name="schools or jobs">
+<table x="132" y="217" name="schools or jobs">
 <row name="id" null="1" autoincrement="1">
 <datatype>INTEGER</datatype>
 <default>NULL</default></row>
 <row name="name" null="1" autoincrement="0">
 <datatype>VARCHAR</datatype>
 <default>NULL</default></row>
-<row name="super_category_id" null="1" autoincrement="0">
+<row name="sub_category_id" null="1" autoincrement="0">
 <datatype>INTEGER</datatype>
-<default>NULL</default><relation table="super_categories" row="id" />
+<default>NULL</default><relation table="sub_categories" row="id" />
 </row>
 <key type="PRIMARY" name="">
 <part>id</part>
 </key>
 </table>
-<table x="31" y="70" name="sub_categories">
+<table x="174" y="68" name="sub_categories">
 <row name="id" null="1" autoincrement="1">
 <datatype>INTEGER</datatype>
 <default>NULL</default></row>
@@ -168,6 +174,28 @@
 <datatype>INTEGER</datatype>
 <default>NULL</default><relation table="super_categories" row="id" />
 </row>
+<key type="PRIMARY" name="">
+<part>id</part>
+</key>
+</table>
+<table x="77" y="384" name="skills_scores">
+<row name="id" null="1" autoincrement="1">
+<datatype>INTEGER</datatype>
+<default>NULL</default></row>
+<row name="sub_category_id" null="1" autoincrement="0">
+<datatype>INTEGER</datatype>
+<default>NULL</default><relation table="sub_categories" row="id" />
+</row>
+<row name="user_id" null="1" autoincrement="0">
+<datatype>INTEGER</datatype>
+<default>NULL</default><relation table="Users" row="id" />
+</row>
+<row name="viewed_videos" null="1" autoincrement="0">
+<datatype>INTEGER</datatype>
+<default>NULL</default></row>
+<row name="skill_score" null="1" autoincrement="0">
+<datatype>INTEGER</datatype>
+<default>NULL</default></row>
 <key type="PRIMARY" name="">
 <part>id</part>
 </key>

--- a/db/migrate/20180903080629_add_interest_scores_to_scores.rb
+++ b/db/migrate/20180903080629_add_interest_scores_to_scores.rb
@@ -1,0 +1,5 @@
+class AddInterestScoresToScores < ActiveRecord::Migration[5.2]
+  def change
+    add_column :scores, :interest_score, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_31_111853) do
+ActiveRecord::Schema.define(version: 2018_09_03_080629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2018_08_31_111853) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "viewed_videos", default: 0
+    t.integer "interest_score", default: 0
     t.index ["super_category_id"], name: "index_scores_on_super_category_id"
     t.index ["user_id"], name: "index_scores_on_user_id"
   end

--- a/future_database_schem.xml
+++ b/future_database_schem.xml
@@ -123,7 +123,7 @@
 <part>id</part>
 </key>
 </table>
-<table x="496" y="269" name="interest_scores">
+<table x="496" y="269" name="scores">
 <row name="id" null="1" autoincrement="1">
 <datatype>INTEGER</datatype>
 <default>NULL</default></row>
@@ -148,7 +148,7 @@
 <part>id</part>
 </key>
 </table>
-<table x="132" y="217" name="schools or jobs">
+<table x="132" y="226" name="schools or jobs">
 <row name="id" null="1" autoincrement="1">
 <datatype>INTEGER</datatype>
 <default>NULL</default></row>
@@ -173,6 +173,10 @@
 <row name="super_category_id" null="1" autoincrement="0">
 <datatype>INTEGER</datatype>
 <default>NULL</default><relation table="super_categories" row="id" />
+</row>
+<row name="parant_id" null="1" autoincrement="0">
+<datatype>INTEGER</datatype>
+<default>NULL</default><relation table="sub_categories" row="id" />
 </row>
 <key type="PRIMARY" name="">
 <part>id</part>


### PR DESCRIPTION
Future db schema has parent_id feature in sub_categories table: 
![image](https://user-images.githubusercontent.com/38688523/44975100-d7ae1a00-af61-11e8-9712-2593221fcd18.png)

Current db does not include parent_id: 
![image](https://user-images.githubusercontent.com/38688523/44975149-ff04e700-af61-11e8-8eed-4738436133a0.png)

